### PR TITLE
It's a read-only message and should be shown only once.

### DIFF
--- a/staking_contact/lib.rs
+++ b/staking_contact/lib.rs
@@ -495,7 +495,7 @@ pub mod staking_contract {
         ///function to get the amount of tokens to give to caller each day.
         #[ink(message)]
         pub fn get_amount_to_give_each_day_to_caller(
-            &mut self,
+            &self,
             caller:AccountId
         )   -> Balance  {
         


### PR DESCRIPTION
Criticality: Low

The &mut self is not required for this message macro because it is a read-only message and doesn't need a signatory.